### PR TITLE
A fix for a crash when server is started via listen()

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,12 @@ Git.prototype.create = function (repo, cb) {
 
 Git.prototype.handle = handle;
 Git.prototype.listen = function(port, callback) {
-    http.createServer(function (req, res) {
-        handle(req, res);
-    }).listen(port, callback);
+    var self = this;
+    this.server = http.createServer(function (req, res) {
+        self.handle(req, res);
+    });
+    this.server.listen(port, callback);
+}
+Git.prototype.close = function() {
+    this.server.close();
 }

--- a/test/internal-http-server.js
+++ b/test/internal-http-server.js
@@ -34,7 +34,7 @@ test('create git server via listen() command', function (t) {
         },
     ], function(err) {
         t.ok(!err, 'no errors');
-        server.close();
+        repos.close();
         t.end();
     })
 });

--- a/test/internal-http-server.js
+++ b/test/internal-http-server.js
@@ -1,0 +1,40 @@
+var test = require('tape');
+var pushover = require('../');
+
+var fs = require('fs');
+
+var spawn = require('child_process').spawn;
+
+var async = require('async');
+
+test('create git server via listen() command', function (t) {
+    t.plan(2);
+
+    var repoDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
+    var srcDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
+    var dstDir = '/tmp/' + Math.floor(Math.random() * (1<<30)).toString(16);
+
+    fs.mkdirSync(repoDir, 0700);
+    fs.mkdirSync(srcDir, 0700);
+    fs.mkdirSync(dstDir, 0700);
+
+    var repos = pushover(repoDir);
+    var port = Math.floor(Math.random() * ((1<<16) - 1e4)) + 1e4;
+    repos.listen(port)
+
+    process.chdir(srcDir);
+    async.waterfall([
+        function (callback) {
+            process.chdir(dstDir);
+            spawn('git', [ 'clone', 'http://localhost:' + port + '/doom' ])
+            .on('exit', function (code) {
+                t.equal(code, 0);
+                callback();
+            });
+        },
+    ], function(err) {
+        t.ok(!err, 'no errors');
+        server.close();
+        t.end();
+    })
+});


### PR DESCRIPTION
hi @gabrielcsapo,
this is a fix for #2.

I had to add a `close()` method also. It was needed to close a server in a testcase.