### PR TITLE
adds helpful message to the example instead of printing 'undefined'

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -30,6 +30,10 @@ git.listen(port, (error) => {
     if(error) return console.error(`failed to start git-server because of error ${error}`); // eslint-disable-line
     console.log(`node-git-server running at http://localhost:${port}`); // eslint-disable-line
     git.list((err, result) => {
-        console.log(result); // eslint-disable-line
+        if (!result) {
+            console.log("No repositories available..."); // eslint-disable-line
+        } else {
+            console.log(result); // eslint-disable-line
+        }
     });
 });


### PR DESCRIPTION
Just a simple message to demystify why 'undefined' is actually printed