### PR TITLE
Removes dependency on http-duplex package replacing w/ internal replacement lib

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -3,7 +3,7 @@ const path = require('path');
 const http = require('http');
 const url = require('url');
 const qs = require('querystring');
-const httpDuplex = require('http-duplex');
+const httpDuplex = require('./http-duplex');
 
 const { spawn } = require('child_process');
 const { EventEmitter } = require('events');
@@ -324,7 +324,7 @@ class Git extends EventEmitter {
 
             self.exists(repo, (ex) => {
                 const anyListeners = self.listeners('head').length > 0;
-                const dup = httpDuplex(req, res);
+                const dup = new httpDuplex(req, res);
                 dup.exists = ex;
                 dup.repo = repo;
                 dup.cwd = self.dirMap(repo);

--- a/lib/http-duplex.js
+++ b/lib/http-duplex.js
@@ -1,0 +1,130 @@
+const EventEmitter = require('events');
+
+/** Updated/Simplified http-duplex replacement.
+ * Creates a unified stream from the passed in streams input and output.
+ * Generally meant to combine http.req (input) and http.res (output) streams
+ * @class HttpDuplex
+ * @extends EventEmitter
+ */
+
+class HttpDuplex extends EventEmitter {
+    /**
+     * Constructs a proxy object over input and output.
+     * @constructor
+     * @param {stream.readable} input - http request object
+     * @param {stream.writeable} output - http response object
+     */
+    constructor(input, output) {
+        super();
+
+        this.req = input;
+        this.res = output;
+
+        var self = this;
+
+        // request / input proxy events
+        ['data', 'end', 'error', 'close'].forEach(function (name) {
+            self.req.on(name, self.emit.bind(self, name));
+        });
+
+        // respone / output proxy events
+        ['error', 'drain'].forEach(function (name) {
+            self.res.on(name, self.emit.bind(self, name));
+        });
+    }
+
+    // input / request wrapping
+    get client() {
+        return this.req.client;
+    }
+
+    get complete() {
+        return this.req.complete;
+    }
+
+    get connection() {
+        return this.req.connection;
+    }
+
+    get headers() {
+        return this.req.headers;
+    }
+
+    get httpVersion() {
+        return this.req.httpVersion;
+    }
+
+    get httpVersionMajor() {
+        return this.req.httpVersionMajor;
+    }
+
+    get httpVersionMinor() {
+        return this.req.httpVersionMinor;
+    }
+
+    get method() {
+        return this.req.method;
+    }
+
+    get readable() {
+        return this.req.readable;
+    }
+
+    get socket() {
+        return this.req.socket;
+    }
+
+    get trailers() {
+        return this.req.trailers;
+    }
+
+    get upgrade() {
+        return this.req.upgrade;
+    }
+
+    get url() {
+        return this.req.url;
+    }
+
+    // output / response wrapping
+    get writable() {
+        return this.res.writable;
+    }
+
+    get statusCode() {
+        return this.res.statusCode;
+    }
+
+    set statusCode(val) {
+        this.res.statusCode = val;
+    }
+
+}
+
+// proxy request methods
+['pause', 'resume', 'setEncoding'].forEach(function (name) {
+    HttpDuplex.prototype[name] = function () {
+        return this.req[name].apply(this.req, Array.from(arguments));
+    };
+});
+
+// proxy respone methods
+[
+    'cork', 'uncork', 'setDefaultEncoding', 'write', 'end', 'flush', 'writeHeader', 'writeHead', 'writeContinue',
+    'setHeader', 'getHeader', 'removeHeader', 'addTrailers'
+].forEach(function (name) {
+    HttpDuplex.prototype[name] = function () {
+        return this.res[name].apply(this.res, Array.from(arguments));
+    };
+});
+
+/**
+  * destroys stream object and it's bound streams
+  * @method destroy
+  */
+HttpDuplex.prototype.destroy = function () {
+    this.req.destroy();
+    this.res.destroy();
+};
+
+module.exports = HttpDuplex;

--- a/lib/service.js
+++ b/lib/service.js
@@ -1,5 +1,5 @@
 const through = require('through');
-const HttpDuplex = require('http-duplex');
+const HttpDuplex = require('./http-duplex');
 const zlib = require('zlib');
 
 const { spawn } = require('child_process');

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@
  * @module lib/util
  */
 
-const httpDuplex = require('http-duplex');
+const httpDuplex = require('./http-duplex');
 const { spawn } = require('child_process');
 
 const Service = require('./service');
@@ -86,7 +86,7 @@ const Util = {
   },
   infoResponse: function infoResponse(opts, req, res) {
     var self = opts.repos;
-    var dup = httpDuplex(req, res);
+    var dup = new httpDuplex(req, res);
     dup.cwd = self.dirMap(opts.repo);
     dup.repo = opts.repo;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "generate-docs": "tryitout --template=landing --output=./docs && jsdoc -c jsdoc.json"
   },
   "dependencies": {
-    "http-duplex": "~0.0.2",
     "through": "^2.3.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.2",
   "description": "🎡 A configurable git server written in Node.js",
   "author": "Gabriel J. Csapo <gabecsapo@gmail.com>",
+  "contributors": [{
+      name: "echopoint",
+      email: "echopoint <echopoint@tutanota.com>"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gabrielcsapo/node-git-server/issues"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "🎡 A configurable git server written in Node.js",
   "author": "Gabriel J. Csapo <gabecsapo@gmail.com>",
   "contributors": [{
-      name: "echopoint",
-      email: "echopoint <echopoint@tutanota.com>"
+      "name": "echopoint",
+      "email": "echopoint <echopoint@tutanota.com>"
   }],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Examined and wrote a different version of the proxy object that http-duplex supplies without additional dependencies. Removed node's util.inherits because it seems they are looking to deprecate that way of inheriting objects. Tested locally with an 80GB repo and didn't have any issues with passing data over it. Please test and let me know of any errors. Should take care of https://github.com/gabrielcsapo/node-git-server/issues/7