### PR TITLE
remove useless 'new' calls

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -58,7 +58,7 @@ class Service extends HttpDuplex {
     if(req.headers["authorization"]) {
       const tokens = req.headers["authorization"].split(" ");
       if (tokens[0] === "Basic") {
-          const splitHash = new Buffer.from(tokens[1], 'base64').toString('utf8').split(":");
+          const splitHash = Buffer.from(tokens[1], 'base64').toString('utf8').split(":");
           this.username = splitHash.shift();
       }
     }
@@ -141,7 +141,7 @@ class Service extends HttpDuplex {
             };
 
             self.emit('response', respStream, function endResponse() {
-                res.queue(new Buffer.from('0000'));
+                res.queue(Buffer.from('0000'));
                 res.queue(null);
             });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -34,7 +34,7 @@ const Util = {
       } else {
           const tokens = req.headers["authorization"].split(" ");
           if (tokens[0] === "Basic") {
-              const splitHash = new Buffer.from(tokens[1], 'base64').toString('utf8').split(":");
+              const splitHash = Buffer.from(tokens[1], 'base64').toString('utf8').split(":");
               const username = splitHash.shift();
               const password = splitHash.join(":");
               callback(username, password, null);


### PR DESCRIPTION
`Buffer.from` is not a constructor, those `new` keywords weren't needed.