### PR TITLE
Security Issue

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -143,7 +143,7 @@ class Git extends EventEmitter {
         this.dirMap = repoDir;
     } else {
         this.dirMap = (dir) => {
-            return (path.normalize(dir ? path.resolve(repoDir, dir) : repoDir));
+            return (path.normalize(dir ? path.join(repoDir, dir) : repoDir));
         };
     }
 


### PR DESCRIPTION
It is currently possible to overwrite the `repoDir` by sending a repository name that starts with `/`, the `path.resolve` method prioritizes the second argument see the example below.

```js
path.resolve("/my/repo/folder","/etc");
// /etc
```

This behavior gives an attacker the ability to push/pull/clone repositories from an arbitrary absolute path, this could also impact authentication in some cases as it corrupts the repository name.

**Reproduction**
The following will clone a repository from an absolute path.

```shell
git clone http://localhost:7005//Users/root/Desktop/testrepo.git ./cloned-from-desktop
```
The same technique could be used for `git push/pull`