### PR TITLE
tag.version is the tag not the repo

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -36,7 +36,7 @@ const services = ['upload-pack', 'receive-pack'];
   * @property {HttpDuplex} tag - an http duplex object (see below) with these extra properties:
   * @property {String} tag.repo - the string that defines the repo
   * @property {String} tag.commit - the string that defines the commit sha
-  * @property {String} tag.version - the string that defines the repo
+  * @property {String} tag.version - the string that defines the tag being pushed
   * @example
     repos.on('tag', function (tag) { ... }
 


### PR DESCRIPTION
Minor fix in the docs. I believe this is the correct change, but I'm not 100% sure.

I'm also not sure why the variable is called `version` when it seems to contain the value of the tag being pushed. But this might make sense based on how git works internally, I'm not super familiar with it.