### PR TITLE
Add `repoTemplatePath` as a startup option.

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -135,6 +135,7 @@ class Git extends EventEmitter {
        });
      }
    * @param  {Boolean=}  options.checkout - If `opts.checkout` is true, create and expected checked-out repos instead of bare repos
+   * @param  {String}  options.repoTemplatePath - If specified, this path will be given to the `git init --template=options.repoTemplatePath` command like so
   */
   constructor(repoDir, options={}) {
     super();
@@ -150,6 +151,7 @@ class Git extends EventEmitter {
     this.authenticate = options.authenticate;
     this.autoCreate = options.autoCreate === false ? false : true;
     this.checkout = options.checkout;
+    this.repoTemplatePath = options.repoTemplatePath;
   }
   /**
    * Get a list of all the repositories
@@ -223,7 +225,11 @@ class Git extends EventEmitter {
 
           var dir = self.dirMap(repo);
           if (self.checkout) {
-              ps = spawn('git', [ 'init', dir ]);
+              if (self.repoTemplatePath) {
+                  ps = spawn('git', [ 'init', '--template=' + self.repoTemplatePath, dir ]);
+              } else {
+                  ps = spawn('git', [ 'init', dir ]);
+              }
           }
           else {
               ps = spawn('git', [ 'init', '--bare', dir ]);


### PR DESCRIPTION
This passes the `--template=...` flag to the `git init` command. This allows config values and other defaults to be overwritten for newly created repositories.

I've tested this a bit locally and it seems to work. I haven't added any tests to `tests/git.js` though. I've noticed this repo has been a bit quiet in recent times, so I'll also publish this under my own scope as `@chmac/node-git-server` as I want to use this right away, and it's not clear if / when you might get around to reviewing PRs.

Thanks again for the code, node-git-server has saved me a ton of effort to get a simple git backend hosting service running.