### PR TITLE
Improve authentication in example and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,11 @@ const repos = new Server(path.resolve(__dirname, 'tmp'), {
       if(type == 'push') {
         user((username, password) => {
           console.log(username, password);
-          next();
+          if (accountName === '42' && password === '42') {
+            next();
+          } else {
+            next('wrong password');
+          }
         });
       } else {
         next();

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ const repos = new Server(path.resolve(__dirname, 'tmp'), {
     autoCreate: true,
     authenticate: ({type, repo, user}, next) => {
       if(type == 'push') {
+        // Decide if this user is allowed to perform this action against this repo.
         user((username, password) => {
           console.log(username, password);
           if (accountName === '42' && password === '42') {
@@ -140,6 +141,7 @@ const repos = new Server(path.resolve(__dirname, 'tmp'), {
           }
         });
       } else {
+        // Check these credentials are correct for this user.
         next();
       }
     }

--- a/example/index.js
+++ b/example/index.js
@@ -29,7 +29,11 @@ const repos = new Server(path.normalize(path.resolve(__dirname, 'tmp')), {
       if(type == 'push') {
         user((username, password) => {
           console.log(username, password); // eslint-disable-line
-          next();
+          if (accountName === '42' && password === '42') {
+            next();
+          } else {
+            next('wrong password');
+          }
         });
       } else {
         next();

--- a/example/index.js
+++ b/example/index.js
@@ -27,6 +27,7 @@ const repos = new Server(path.normalize(path.resolve(__dirname, 'tmp')), {
     authenticate: ({ type, repo, user, headers }, next) => {
       console.log(type, repo, headers); // eslint-disable-line
       if(type == 'push') {
+        // Decide if this user is allowed to perform this action against this repo.
         user((username, password) => {
           console.log(username, password); // eslint-disable-line
           if (accountName === '42' && password === '42') {
@@ -36,6 +37,7 @@ const repos = new Server(path.normalize(path.resolve(__dirname, 'tmp')), {
           }
         });
       } else {
+        // Check these credentials are correct for this user.
         next();
       }
     }


### PR DESCRIPTION
The authentication code in the example app (and readme) currently allows all requests. This small update demonstrates how to actually perform authentication, including rejection by calling `next()` with an error message string.