### PR TITLE
Allow any ref, not just tags or branches

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -7,8 +7,9 @@ const { spawn } = require('child_process');
 const HttpDuplex = require('./http-duplex');
 
 const headerRE = {
-  'receive-pack': '([0-9a-fA-F]+) ([0-9a-fA-F]+) refs\/(heads|tags)\/(.*?)( |00|\u0000)|^(0000)$', // eslint-disable-line
-  'upload-pack': '^\\S+ ([0-9a-fA-F]+)'
+  "receive-pack":
+    "([0-9a-fA-F]+) ([0-9a-fA-F]+) refs/([^/]+)/(.*?)( |00|\u0000)|^(0000)$", // eslint-disable-line
+  "upload-pack": "^\\S+ ([0-9a-fA-F]+)",
 };
 
 const packSideband = s => {


### PR DESCRIPTION
The current regex for parsing a receive-pack payload assumes the ref will be of the form:

    refs/tags/:tag-name

or

    refs/heads/:branch-name

We'd like to be able to push arbitrary refs, like

    refs/any/thing/we/like

The goal of this PR is to make that change, with tests and any neccesary changes to the outside API / internal model.
